### PR TITLE
feat: Deprecate Line.allInMapOrder

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/emma-k-alexandra/WMATA.swift",
         "state": {
           "branch": null,
-          "revision": "bed033b5c3e5e9ee88ffd4aea30ef0194fd2dd08",
-          "version": "13.0.0"
+          "revision": "00dd3eeb9db17c4e9f2f0f3cd081c0cdf036c08c",
+          "version": "13.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["WMATAUI"])
     ],
     dependencies: [
-        .package(name: "WMATA", url: "https://github.com/emma-k-alexandra/WMATA.swift", from: "13.0.0"),
+        .package(name: "WMATA", url: "https://github.com/emma-k-alexandra/WMATA.swift", from: "13.1.0"),
         .package(name: "ViewInspector", url: "https://github.com/nalexn/ViewInspector", from: "0.9.0")
     ],
     targets: [

--- a/Sources/WMATAUI/LineUI.swift
+++ b/Sources/WMATAUI/LineUI.swift
@@ -71,7 +71,8 @@ public extension Line {
 public extension Line {
 
     /// All lines in the order listed on the [2019 System Map](https://wmata.com/schedules/maps/upload/2019-System-Map.pdf).
-    static let allInMapOrder: [Line] = [.red, .orange, .blue, .green, .yellow, .silver]
+    @available(swift, deprecated: 0.7.1, message: "Use Line.allCases instead.")
+    static let allInMapOrder: [Line] = Line.allCases
 }
 
 /// Conformance with Comparable
@@ -79,6 +80,6 @@ extension Line: Comparable {
     
     /// Sort an array of Line by the order shown in the Metrorail map legend
     public static func < (lhs: Line, rhs: Line) -> Bool {
-        allInMapOrder.firstIndex(of: lhs)! < allInMapOrder.firstIndex(of: rhs)!
+        allCases.firstIndex(of: lhs)! < allCases.firstIndex(of: rhs)!
     }
 }

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -39,9 +39,7 @@ final class LinesUITests: XCTestCase {
     }
 
     func testAllInMapOrder() {
-        Line.allCases.forEach {
-            XCTAssertTrue(Line.allInMapOrder.contains($0), "Expected \($0) to be present")
-        }
+        XCTAssertEqual(Line.allCases, Line.allInMapOrder)
     }
 
     func testComparable() {


### PR DESCRIPTION
Since Line.allCases now is in map order, it is not necessary to have a separate variable for the map order.