### PR TITLE
feat: Allow Roundel to be a symbol

### DIFF
--- a/Sources/WMATAUI/LineUI.swift
+++ b/Sources/WMATAUI/LineUI.swift
@@ -83,3 +83,21 @@ extension Line: Comparable {
         allCases.firstIndex(of: lhs)! < allCases.firstIndex(of: rhs)!
     }
 }
+
+@available(iOS 14.0, *)
+@available(macCatalyst 14.0, *)
+@available(macOS 11.0, *)
+struct Line_Preview: PreviewProvider {
+    static var previews: some View {
+        let style = Font.TextStyle.largeTitle
+        VStack {
+            ForEach(Line.allCases, id: \.rawValue) { line in
+                HStack {
+                    line.roundel(style: style)
+                    Text(line.name)
+                        .font(.metroFont(style))
+                }
+            }
+        }
+    }
+}

--- a/Sources/WMATAUI/WMATAUI.swift
+++ b/Sources/WMATAUI/WMATAUI.swift
@@ -40,11 +40,85 @@ public struct WMATAUI {
     @available(macCatalyst 14.0, *)
     @available(macOS 11.0, *)
     public static func roundel(text: String, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
+        WMATAUI.roundel(view: AnyView(Text(text)),
+                        color: color,
+                        textColor: textColor,
+                        style: style,
+                        factor: factor)
+    }
+
+    /// Get a color dot sized for the given text style with an image within it. This really works only for symbols.
+    ///
+    /// To get a roundel where the line code text size matches the style size, use a factor of `2.0`.
+    ///
+    ///  - Parameter image: The image to display.
+    ///  - Parameter color: The color of the dot.
+    ///  - Parameter textColor: The color of the text in the dot.
+    ///  - Parameter style: The style to match.
+    ///  - Parameter factor: Optional factor to multiply the point size of the style by; defaults to `1.0`.
+    ///
+    /// - Returns: A circle in in the given color sized to match the text style with the given image in a smaller size.
+    @available(iOS 14.0, *)
+    @available(macCatalyst 14.0, *)
+    @available(macOS 11.0, *)
+    public static func roundel(image: Image, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
+        WMATAUI.roundel(view: AnyView(image),
+                        color: color,
+                        textColor: textColor,
+                        style: style,
+                        factor: factor)
+    }
+
+    /// Get a color dot sized for the given view. This really works only for symbols or one or two character strings.
+    ///
+    /// To get a roundel where the line code text size matches the style size, use a factor of `2.0`.
+    ///
+    ///  - Parameter view: The view to display.
+    ///  - Parameter color: The color of the dot.
+    ///  - Parameter textColor: The color of the text in the dot.
+    ///  - Parameter style: The style to match.
+    ///  - Parameter factor: Optional factor to multiply the point size of the style by; defaults to `1.0`.
+    ///
+    /// - Returns: A circle in in the given color sized to match the text style with the given view in a smaller size.
+    @available(iOS 14.0, *)
+    @available(macCatalyst 14.0, *)
+    @available(macOS 11.0, *)
+    private static func roundel(view: AnyView, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
         ZStack {
             WMATAUI.dot(color: color, style: style, factor: 1.0 * factor)
-            Text(text)
+            view
                 .font(.metroFont(style, factor: 0.5 * factor).weight(.bold))
                 .foregroundColor(textColor)
+        }
+    }
+}
+
+@available(iOS 14.0, *)
+@available(macCatalyst 14.0, *)
+@available(macOS 11.0, *)
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        let style = Font.TextStyle.largeTitle
+        VStack {
+            HStack {
+                WMATAUI.roundel(text: "AB", color: .purple, textColor: .white, style: style)
+                Text("Text Fits").font(.metroFont(style))
+            }
+            HStack {
+                WMATAUI.roundel(text: "CDE", color: .purple, textColor: .white, style: style)
+                Text("Text To Long").font(.metroFont(style))
+            }
+            HStack {
+                WMATAUI.roundel(image: Image(systemName: "tram.fill"), color: .purple, textColor: .white, style: style)
+                Text("System Image").font(.metroFont(style))
+            }
+            Text("Different Colors:")
+            HStack {
+                WMATAUI.roundel(image: Image(systemName: "tram.fill"), color: .gray, textColor: .purple, style: style)
+                WMATAUI.roundel(image: Image(systemName: "tram.fill"), color: .white, textColor: .green, style: style)
+                WMATAUI.roundel(image: Image(systemName: "tram.fill"), color: .green, textColor: .white, style: style)
+                WMATAUI.roundel(image: Image(systemName: "tram.fill"), color: .green, textColor: .black, style: style)
+            }
         }
     }
 }


### PR DESCRIPTION
Technically, this allows a Roundel to contain any Image, but the reality of images is that they only really work for symbols.