### PR TITLE
fix: Scale dots properly with Dynamic Type

### DIFF
--- a/Sources/WMATAUI/LineUI.swift
+++ b/Sources/WMATAUI/LineUI.swift
@@ -46,7 +46,7 @@ public extension Line {
     /// - Parameter factor: Optional factor to multiply the point size of the style by, defaults to 0.9.
     ///
     /// - Returns: A circle in in the color of this line sized to match the text style.
-    @available(macOS 11.0, *)
+    @available(macOS 11.0, iOS 14.0, *)
     func dot(style: Font.TextStyle, factor: CGFloat = 0.9) -> some View {
         WMATAUI.dot(color: self.color, style: style, factor: factor)
     }

--- a/Sources/WMATAUI/WMATAUI.swift
+++ b/Sources/WMATAUI/WMATAUI.swift
@@ -19,8 +19,7 @@ public struct WMATAUI {
     /// - Returns: A circle in in the given color sized to match the text style.
     @available(macOS 11.0, iOS 14.0, *)
     public static func dot(color: Color, style: Font.TextStyle, factor: CGFloat = 0.9) -> some View {
-
-        return Image(systemName: "circle.fill")
+        Image(systemName: "circle.fill")
             .foregroundColor(color)
             .font(.metroFont(style, factor: factor))
     }

--- a/Sources/WMATAUI/WMATAUI.swift
+++ b/Sources/WMATAUI/WMATAUI.swift
@@ -17,12 +17,12 @@ public struct WMATAUI {
     /// - Parameter factor: Optional factor to multiply the point size of the style by; defaults to `0.9`.
     ///
     /// - Returns: A circle in in the given color sized to match the text style.
-    @available(macOS 11.0, *)
+    @available(macOS 11.0, iOS 14.0, *)
     public static func dot(color: Color, style: Font.TextStyle, factor: CGFloat = 0.9) -> some View {
-        let size = WMATAUIFont.preferredFont(forTextStyle: .with(textStyle: style)).pointSize * factor
-        return Circle()
+
+        return Image(systemName: "circle.fill")
             .foregroundColor(color)
-            .frame(width: size, height: size, alignment: .center)
+            .font(.metroFont(style, factor: factor))
     }
 
     /// Get a color dot sized for the given text style with a smaller text within it. This really works only for one or two character strings.
@@ -39,8 +39,8 @@ public struct WMATAUI {
     @available(iOS 14.0, *)
     @available(macCatalyst 14.0, *)
     @available(macOS 11.0, *)
-    public static func roundel(text: String, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
-        WMATAUI.roundel(view: AnyView(Text(text)),
+    public static func roundel<S: StringProtocol>(text: S, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
+        WMATAUI.roundel(view: Text(text),
                         color: color,
                         textColor: textColor,
                         style: style,
@@ -62,7 +62,7 @@ public struct WMATAUI {
     @available(macCatalyst 14.0, *)
     @available(macOS 11.0, *)
     public static func roundel(image: Image, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
-        WMATAUI.roundel(view: AnyView(image),
+        WMATAUI.roundel(view: image,
                         color: color,
                         textColor: textColor,
                         style: style,
@@ -83,11 +83,11 @@ public struct WMATAUI {
     @available(iOS 14.0, *)
     @available(macCatalyst 14.0, *)
     @available(macOS 11.0, *)
-    private static func roundel(view: AnyView, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
+    private static func roundel<Content: View>(view: Content, color: Color, textColor: Color, style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
         ZStack {
-            WMATAUI.dot(color: color, style: style, factor: 1.0 * factor)
+            WMATAUI.dot(color: color, style: style, factor: factor)
             view
-                .font(.metroFont(style, factor: 0.5 * factor).weight(.bold))
+                .font(.metroFont(style, factor: 0.5 * factor).bold())
                 .foregroundColor(textColor)
         }
     }
@@ -120,6 +120,17 @@ struct ContentView_Previews: PreviewProvider {
                 WMATAUI.roundel(image: image, color: .green, textColor: .white, style: style)
                 WMATAUI.roundel(image: image, color: .green, textColor: .black, style: style)
             }
+            HStack {
+                WMATAUI.roundel(text: "AB", color: .purple, textColor: .white, style: style)
+                Text("Huge Text").font(.metroFont(style))
+            }
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+            HStack {
+                WMATAUI.roundel(text: "AB", color: .purple, textColor: .white, style: .caption)
+                Text("Tiny Text").font(.metroFont(.caption))
+            }
+            .environment(\.sizeCategory, .extraSmall)
         }
+        
     }
 }

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -34,12 +34,28 @@ final class LinesUITests: XCTestCase {
     
     func testDotSize() {
         let dot = Line.red.dot(style: .headline, factor: 1.0)
+#if targetEnvironment(macCatalyst) // macCatalyst builds as if iOS without this target environment
+        let baseFontSize = 19.0
+        let largeFontSize = 25.0
+#elseif os(macOS)
+        let baseFontSize = 19.0
+        let largeFontSize = 25.0
+#elseif os(iOS) // not sure if these are iPhone only sizes, or iPhone + iPad sizes
+        let baseFontSize = 19.0
+        let largeFontSize = 55.0
+#elseif os(tvOS)
+        let baseFontSize = 44.0
+        let largeFontSize = 44.0
+#else // watchOS
+        let baseFontSize = 40.0
+        let largeFontSize = 40.0
+#endif
         
         let baseSizeExpectation = expectation(description: #function)
         showView(
             dot
                 .readSize { size in
-                    XCTAssertLessThan(size.height, 40)
+                    XCTAssertEqual(size.height, baseFontSize)
                     baseSizeExpectation.fulfill()
                 }
         )
@@ -49,7 +65,7 @@ final class LinesUITests: XCTestCase {
             dot
                 .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
                 .readSize { size in
-                    XCTAssertGreaterThan(size.height, 40)
+                    XCTAssertEqual(size.height, largeFontSize)
                     largeSizeExpectation.fulfill()
                 }
         )

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -43,7 +43,7 @@ final class LinesUITests: XCTestCase {
                 }
         )
         
-        let largeSizeExpectation = expectation(description: #function)
+        let largeSizeExpectation = expectation(description: "large\(#function)")
         showView(
             dot
                 .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -27,8 +27,8 @@ final class LinesUITests: XCTestCase {
 
     func testDot() {
         let dot = Line.red.dot(style: .headline, factor: 1.0)
-        XCTAssertEqual(try dot.inspect().shape(0).foregroundColor(), .metrorailRed)
-        XCTAssertEqual(try dot.inspect().fixedWidth(),  WMATAUIFont.preferredFont(forTextStyle: .headline).pointSize)
+        XCTAssertEqual(try dot.inspect().image(0).foregroundColor(), .metrorailRed)
+        XCTAssertEqual(try dot.inspect().image(0).actualImage().name(), "circle.fill")
     }
 
     @available(iOS 14.0, *)

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftUI
+import UIKit
 import WMATA
 import ViewInspector
 @testable import WMATAUI

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -4,6 +4,7 @@ import WMATA
 import ViewInspector
 @testable import WMATAUI
 
+@available(macOS 11.0, iOS 14.0, *)
 final class LinesUITests: XCTestCase {
 
     func testColor() {

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -1,6 +1,8 @@
 import XCTest
 import SwiftUI
+#if !os(macOS)
 import UIKit
+#endif
 import WMATA
 import ViewInspector
 @testable import WMATAUI
@@ -32,14 +34,14 @@ final class LinesUITests: XCTestCase {
         XCTAssertEqual(try dot.inspect().image(0).actualImage().name(), "circle.fill")
     }
     
-    func testDotSize() {
+    func testDotSize() throws {
         let dot = Line.red.dot(style: .headline, factor: 1.0)
 #if targetEnvironment(macCatalyst) // macCatalyst builds as if iOS without this target environment
         let baseFontSize = 19.0
         let largeFontSize = 25.0
 #elseif os(macOS)
-        let baseFontSize = 19.0
-        let largeFontSize = 25.0
+        let baseFontSize = 15.0
+        let largeFontSize = 15.0
 #elseif os(iOS) // not sure if these are iPhone only sizes, or iPhone + iPad sizes
         let baseFontSize = 19.0
         let largeFontSize = 55.0
@@ -49,6 +51,7 @@ final class LinesUITests: XCTestCase {
 #else // watchOS
         let baseFontSize = 40.0
         let largeFontSize = 40.0
+        try XCTSkipIf(true, "showView has empty implementation on WatchKit")
 #endif
         
         let baseSizeExpectation = expectation(description: #function)
@@ -111,7 +114,14 @@ extension View {
 }
 
 func showView<T: View>(_ view: T) {
+#if os(macOS)
+    let window = NSWindow()
+    window.contentViewController = NSHostingController(rootView: view)
+    window.makeKeyAndOrderFront(nil)
+#elseif os(watchOS)
+#else
     let window = UIWindow(frame: UIScreen.main.bounds)
     window.rootViewController = UIHostingController(rootView: view)
     window.makeKeyAndVisible()
+#endif
 }


### PR DESCRIPTION
refactor: Use a generic that implements View for roundel content
refactor: Use generic that implements StringProtocol instead of String for public roundel content
test: Add previews for dynamic type roundels

Ran into the following issue when testing dynamic type with roundels. Text scaled properly but the dot did not.
<img width="345" alt="Screen Shot 2022-01-17 at 11 59 11 PM" src="https://user-images.githubusercontent.com/12160372/149874127-3154cdc2-3c5b-452f-87fa-5ab9c2b5eadb.png">

I switched dots to being `circle.fill` symbols, so they'll scale properly with fonts. End results are visible in previews when building for iOS:

<img width="385" alt="Screen Shot 2022-01-17 at 11 59 27 PM" src="https://user-images.githubusercontent.com/12160372/149874409-553de974-5e0f-4536-bea1-3e23e00031c4.png">

It feels like Roundels are a good candidate for being moved into their own View and exposing that instead of a static view builder function. Seems like the current private `WMATAUI.roundel` function would make a great view builder initializer.

I also adjusted the inputs of the `WMATAUI.roundel` family of functions. Switching the private version to a generic conforming to `View` instead of `AnyView`. AnyView tends to have a lot of downsides in my experience due to poor view modifier support and recreating the hierarchy lot leads to performance issues.

I adjusted the `WMATAUI.roundel` that accepts a `String` to accept a generic implementing `StringProtocol`. This can be nice for things like `Substring`. It'd also be a good idea to implement a `Text` initializer to avoid needing to implement initializers like `LocalizedStringKey` and `AttributedString`. 