### PR TITLE
chore: Switch Sonarcloud to automatic analysis

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -51,16 +51,16 @@ jobs:
       #   with:
       #     args: >
       #       -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml
-      - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v3
-      - name: Run sonarqube
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          # to get access to secrets.SONAR_TOKEN, provide GITHUB_TOKEN
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: sonar-scanner
-          -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-          -Dsonar.organization=rhwood
-          -Dsonar.host.url=https://sonarcloud.io/
-          -Dsonar.projectKey=rhwood_WMATAUI.swift
-          -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml
+      #- name: Setup sonarqube
+      #  uses: warchant/setup-sonar-scanner@v3
+      #- name: Run sonarqube
+      #  env:
+      #    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #    # to get access to secrets.SONAR_TOKEN, provide GITHUB_TOKEN
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #  run: sonar-scanner
+      #    -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+      #    -Dsonar.organization=rhwood
+      #    -Dsonar.host.url=https://sonarcloud.io/
+      #    -Dsonar.projectKey=rhwood_WMATAUI.swift
+      #    -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml


### PR DESCRIPTION
Running Sonar's automatic static analysis is not compatible with using Sonar for coverage reporting, but running Sonar analysis in the GitHub CI essentially prevents collaboration, so reverting to automatic analysis. This does mean a new coverage provider is required.