### PR TITLE
chore: cache dependencies in Github actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - uses: actions/cache@v3
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -30,6 +30,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50
+      - uses: actions/cache@v3
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       #- name: Set Xcode version
       #  run: sudo xcode-select -s /Applications/Xcode_13.2.1.app
       - name: Build


### PR DESCRIPTION
This should prevent CodeQL from timing out fetching dependencies.

Fixes #3