### PR TITLE
chore: Use swift 5.8 and caches to build docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,15 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: "5.8"
+      - uses: actions/cache@v3
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Package documentation 🛠
         run: |
           export DOCC_JSON_PRETTYPRINT="YES"


### PR DESCRIPTION
Swift 5.8+ is needed to document extensions.