### PR TITLE
chore: general updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: swift
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "csqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/CSQLite.git",
-      "state" : {
-        "revision" : "9106e983d5e3d5149ee35281ec089484b0def018",
-        "version" : "0.0.3"
-      }
-    },
-    {
       "identity" : "sqlite.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
@@ -23,14 +14,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
-        "version" : "0.10.0"
+        "revision" : "7b1732802ffe30e6a67754bda6c7819e5cb0eb70",
+        "version" : "0.9.11"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,11 @@ let package = Package(
             targets: ["WMATAUI"])
     ],
     dependencies: [
+        // dependencies that incorporating apps may directly depend upon have a minimum version
         .package(url: "https://github.com/emma-k-alexandra/WMATA.swift", from: "15.2.0"),
-        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.9.11"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")
+        // test and documentation dependencies are absolute
+        .package(url: "https://github.com/nalexn/ViewInspector", exact: "0.9.11"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", exact: "1.3.0")
     ],
     targets: [
         .target(

--- a/Sources/WMATAUI/LineUI.swift
+++ b/Sources/WMATAUI/LineUI.swift
@@ -66,7 +66,7 @@ public extension Line {
 }
 
 /// Conformance with ``Comparable``.
-extension Line: Comparable {
+extension Line: @retroactive Comparable {
     
     /// Sort an array of ``Line`` by the order shown in the Metrorail map legend.
     public static func < (lhs: Line, rhs: Line) -> Bool {


### PR DESCRIPTION
Now that I have a MacBook that can run Xcode 16.4, make some general updates to silence a warning, more frequently check for dependency updates, and use exact dependencies.