### PR TITLE
feat: use new Wayfinding styles

### DIFF
--- a/Sources/WMATAUI/LineUI.swift
+++ b/Sources/WMATAUI/LineUI.swift
@@ -11,6 +11,24 @@ import WMATA
 /// SwiftUI dependent extensions to ``Line``.
 public extension Line {
 
+    // New style single letter line names in use after 22 June 2025
+    var newStyle: String {
+        switch self {
+        case .red:
+            return "R"
+        case .orange:
+            return "O"
+        case .blue:
+            return "B"
+        case .green:
+            return "G"
+        case .yellow:
+            return "Y"
+        case .silver:
+            return "S"
+        }
+    }
+
     /// The line color.
     var color: Color {
         switch self {
@@ -61,7 +79,7 @@ public extension Line {
     @available(macCatalyst 14.0, *)
     @available(macOS 11.0, *)
     func roundel(style: Font.TextStyle, factor: CGFloat = 1.0) -> some View {
-        WMATAUI.roundel(text: self.rawValue, color: self.color, textColor: self.textColor, style: style, factor: factor)
+        WMATAUI.roundel(text: self.newStyle, color: self.color, textColor: self.textColor, style: style, factor: factor)
     }
 }
 

--- a/Sources/WMATAUI/WMATAUI.swift
+++ b/Sources/WMATAUI/WMATAUI.swift
@@ -83,7 +83,7 @@ public struct WMATAUI {
         ZStack {
             WMATAUI.dot(color: color, style: style, factor: factor)
             view
-                .font(.metroFont(style, factor: 0.5 * factor).bold())
+                .font(.metroFont(style, factor: 0.7 * factor).bold())
                 .foregroundColor(textColor)
         }
     }
@@ -98,11 +98,11 @@ struct ContentView_Previews: PreviewProvider {
         let image = Image(systemName: "tram.fill")
         VStack {
             HStack {
-                WMATAUI.roundel(text: "AB", color: .purple, textColor: .white, style: style)
+                WMATAUI.roundel(text: "M", color: .purple, textColor: .white, style: style)
                 Text("Text Fits").font(.metroFont(style))
             }
             HStack {
-                WMATAUI.roundel(text: "CDE", color: .purple, textColor: .white, style: style)
+                WMATAUI.roundel(text: "WM", color: .purple, textColor: .white, style: style)
                 Text("Text To Long").font(.metroFont(style))
             }
             HStack {
@@ -117,12 +117,12 @@ struct ContentView_Previews: PreviewProvider {
                 WMATAUI.roundel(image: image, color: .green, textColor: .black, style: style)
             }
             HStack {
-                WMATAUI.roundel(text: "AB", color: .purple, textColor: .white, style: style)
+                WMATAUI.roundel(text: "M", color: .purple, textColor: .white, style: style)
                 Text("Huge Text").font(.metroFont(style))
             }
             .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
             HStack {
-                WMATAUI.roundel(text: "AB", color: .purple, textColor: .white, style: .caption)
+                WMATAUI.roundel(text: "M", color: .purple, textColor: .white, style: .caption)
                 Text("Tiny Text").font(.metroFont(.caption))
             }
             .environment(\.sizeCategory, .extraSmall)

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -80,7 +80,7 @@ final class LinesUITests: XCTestCase {
     @available(macCatalyst 14.0, *)
     func testRoundel() throws {
         let roundel = Line.red.roundel(style: .headline)
-        let text = try roundel.inspect().find(text: Line.red.rawValue)
+        let text = try roundel.inspect().find(text: Line.red.newStyle)
         XCTAssertEqual(try text.attributes().foregroundColor(), Line.red.textColor)
     }
 

--- a/Tests/WMATAUITests/LineUITests.swift
+++ b/Tests/WMATAUITests/LineUITests.swift
@@ -10,6 +10,15 @@ import ViewInspector
 @available(macOS 11.0, iOS 14.0, *)
 final class LinesUITests: XCTestCase {
 
+    func testNewStyle() {
+        XCTAssertEqual(Line.red.newStyle, "R")
+        XCTAssertEqual(Line.orange.newStyle, "O")
+        XCTAssertEqual(Line.blue.newStyle, "B")
+        XCTAssertEqual(Line.green.newStyle, "G")
+        XCTAssertEqual(Line.yellow.newStyle, "Y")
+        XCTAssertEqual(Line.silver.newStyle, "S")
+    }
+
     func testColor() {
         XCTAssertEqual(Line.red.color, .metrorailRed)
         XCTAssertEqual(Line.orange.color, .metrorailOrange)


### PR DESCRIPTION
WMATA is switching to [new line identifiers on 2025-06-22](https://wmata.com/about/news/Metrorail-service-changes-take-effect-Sunday-June-22.cfm).