### PR TITLE
fix(docs): fix links and measures

### DIFF
--- a/Sources/WMATAUI/Color+Extension.swift
+++ b/Sources/WMATAUI/Color+Extension.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 /// WMATA Colors from
-/// [Brand and Style Guidelines 3/2018](https://www.wmata.com/business/procurement/solicitations/documents/Metro_Brand_and_Style_Guidelines.pdf) and
-/// [Signage Standards Manual - Station Signs](https://www.wmata.com/business/procurement/solicitations/documents/Manual%20of%20Graphics%20Standards_03032008_pages_101-201.pdf)
+/// [Brand and Style Guidelines 3/2018](https://web.archive.org/web/20240119175548/https://www.wmata.com/business/procurement/solicitations/documents/Metro_Brand_and_Style_Guidelines.pdf) and
+/// [Signage Standards Manual - Station Signs](https://web.archive.org/web/20201118204550/https://www.wmata.com/business/procurement/solicitations/documents/Manual%20of%20Graphics%20Standards_03032008_pages_101-201.pdf)
 public extension Color {
 
     /// Red Line (Pantone 193c)

--- a/Sources/WMATAUI/WMATAUI.swift
+++ b/Sources/WMATAUI/WMATAUI.swift
@@ -26,7 +26,7 @@ public struct WMATAUI {
 
     /// Get a color dot sized for the given text style with a smaller text within it. This really works only for one or two character strings.
     ///
-    /// To get a roundel where the line code text size matches the style size, use a factor of `1.429`.
+    /// To get a roundel where the line code text size matches the style size, use a factor of `1 / 0.7` or `1.42857142857`.
     /// - Parameters:
     ///    - text: The text to display.
     ///    - color: The color of the dot.
@@ -70,7 +70,7 @@ public struct WMATAUI {
 
     /// Get a color dot sized for the given view. This really works only for symbols or one or two character strings.
     ///
-    /// To get a roundel where the line code text size matches the style size, use a factor of `2.0` when using the default contentFactor.
+    /// To get a roundel where the line code text size matches the style size, use a factor of `2.0` when using the default contentFactor or of `1 / contentFactor` for other size.
     /// - Parameters:
     ///    - view: The view to display.
     ///    - color: The color of the dot.


### PR DESCRIPTION
Replace links from WMATA with links from the Wayback Machine and provide more precise measures and formulas to get certain sizes.